### PR TITLE
Config Builder UX overhaul + Upload/Prefill + Searchable Timezones

### DIFF
--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -185,9 +185,14 @@
     </form>
 
     <div class="actions">
-      <button onclick="downloadJSON()">Download config.json</button>
+      <button type="button" onclick="downloadJSON()">Download config.json</button>
+      <label class="button" style="position:relative; overflow:hidden;">
+        <input id="upload_config" type="file" accept="application/json,.json" style="position:absolute; inset:0; opacity:0; cursor:pointer;" />
+        Upload and prefill
+      </label>
       <a class="button" href="./index.html">Back to Home</a>
     </div>
+    <div id="upload_msg" class="tip"></div>
 
     <h2>Preview</h2>
     <pre id="preview"></pre>
@@ -575,11 +580,13 @@
 
     // initialize from sample, fallback to one default pin
     (async function init(){
+      await fetchSampleVersion();
       await loadSamplePins();
       if (pins.length === 0) { pins.push(newPin()); }
       populateTimezoneSelect();
       setupTimezoneSearch();
       setupCollapsibles();
+      setupUpload();
       renderPinsUI();
       render();
     })();

--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -33,7 +33,8 @@
     .collapse-toggle { border:none; background:none; cursor:pointer; font-size:14px; }
     /* PWM visuals */
     .pin-card { background:#f8fafc; }
-    .window-block { background:#fdfdfd; border-left:4px solid #bae6fd; }
+    .window-block { background:#f8fbff; border-left:4px solid #bae6fd; }
+    .window-head { font-size: 12px; color: #4b5563; margin-bottom: 6px; display:flex; align-items:center; gap:6px; }
     /* password reveal */
     .password-wrapper { position: relative; }
     .reveal-btn { position: absolute; right: 8px; top: 50%; transform: translateY(-50%); background: transparent; border: none; cursor: pointer; font-size: 14px; }
@@ -383,7 +384,9 @@
           block.style.borderRadius = '6px';
           block.style.padding = '8px';
           block.style.margin = '8px 0';
+          block.style.background = '#f7f7f7';
           block.innerHTML = `
+            <div class="window-head">🪟 Window ${widx+1}</div>
             <div class="row">
               <label>Window title
                 <input type="text" value="${w.name ?? (widx===0?'day':`w${widx+1}`)}" data-type="win-name" />


### PR DESCRIPTION
## PR: Config Builder UX overhaul + Upload/Prefill + Searchable Timezones

### Summary
This PR modernizes the helper app’s config builder with a cleaner, more intuitive UI and adds the ability to upload an existing config to prefill the form, guarded by a version compatibility check.

### Key changes
- __Dynamic PWM Pins UI__ ([helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0))
  - Up to 5 pins, each with 1–5 time windows.
  - Window title used as JSON key; first unnamed defaults to `day`.
  - Start/end support sunrise/sunset/custom with `<input type="time">`.
  - Duty cycle as 0–100 slider with live numeric display.
  - Subtle window headers and container background for clarity.

- __Timezone selector__
  - Searchable list of common timezones with offset mapping.
  - Writes to `timezone.name` and `timezone.offset`.
  - Defaults to IST; selection updates JSON preview live.

- __Upload and Prefill JSON__ (new)
  - Button to upload any JSON config and prefill the form.
  - __Version compatibility check__: only accepts when uploaded version’s `major.minor` matches the sample (e.g., 0.4.x).
  - Shows user feedback on success/error.

- __Collapsible sections__ for all fieldsets
  - Toggle (▶/▼) on legends to reduce visual clutter.

- __WiFi password reveal__
  - Hidden by default with closed-eye button (🙈).
  - Toggle shows text with open-eye (👁️) and updates aria-label.

- __Styling and responsiveness__
  - Subtle color accents and emojis per section (Meta, WiFi, Timezone, Hardware, System, Notifications, PWM).
  - Global box-sizing and grid improvements to prevent input overflow/overlap.
  - Title emoji updated to __gear__ to match home link.
  - PWM windows get a dedicated container background and “🪟 Window N” header.

- __Homepage link emoji__
  - [helper-app/index.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/index.html:0:0-0:0): “Create config.json” link now uses a gear emoji.

### Files touched
- [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0) (major updates)
- [helper-app/index.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/index.html:0:0-0:0) (gear emoji for builder link)

### Compatibility
- JSON schema unchanged; output aligns with [config.json.sample](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/config.json.sample:0:0-0:0).
- Version check prevents mismatched uploads (compares major.minor only).

### How to test
1. Open [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0) locally.
2. Verify:
   - Collapsible sections toggle open/closed.
   - WiFi password reveal icon switches between 🙈/👁️ and masks/unmasks.
   - Timezone search filters and updates hidden name/offset.
   - Add/remove PWM pins and windows; sliders update live; custom time shows time picker.
   - Window titles reflect in preview JSON as keys, with first unnamed => `day`.
3. Upload a valid JSON with same major.minor version; ensure the form pre-fills.
4. Upload a JSON with a different major.minor; expect a validation error message.
5. Download generated JSON and confirm schema.

### Notes
- Timezone list is curated, not full IANA. Can be extended or made IANA-based if desired.
- Optional future work: soft validation under preview (enabled pins require 2–5 windows, at least one enabled pin, GPIO conflict hints with RTC pins 20/21).

### Checklist
- [x] Dynamic PWM with sliders and time pickers
- [x] Searchable timezone selector with mapping
- [x] Upload + prefill with major.minor version check
- [x] Collapsible sections
- [x] Password reveal toggle
- [x] Responsive layout and input overflow fixes
- [x] Subtle visual hierarchy for PWM window blocks
- [x] Gear emoji alignment on title and homepage link

Please review and merge into the base branch.