### PR TITLE
Validation: window continuity and 24h wrap-around per GPIO

### DIFF
--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -39,6 +39,10 @@
     .sub-toggle { border:none; background:none; cursor:pointer; font-size:12px; padding:0 4px; }
     .window-block.collapsed > .window-body { display:none; }
     .pin-card .gpio-body.collapsed { display:none; }
+    /* validation */
+    .validation { margin-top:6px; font-size:12px; }
+    .validation.ok { color:#065f46; }
+    .validation.err { color:#b91c1c; }
     /* password reveal */
     .password-wrapper { position: relative; }
     .reveal-btn { position: absolute; right: 8px; top: 50%; transform: translateY(-50%); background: transparent; border: none; cursor: pointer; font-size: 14px; }
@@ -378,6 +382,7 @@
             </div>
             <div class="tip">Windows (min ${MIN_WINDOWS}, max ${MAX_WINDOWS}). Note: device requires at least a 'day' window and 2–5 windows when the pin is enabled.</div>
             <div class="windows"></div>
+            <div class="validation" data-role="validation"></div>
           </div>
         `;
 
@@ -430,6 +435,10 @@
               }
             }
             if (t === 'duty') { let v = parseInt(e.target.value||'0'); if (isNaN(v)) v=0; v=Math.max(0,Math.min(100,v)); w.duty_cycle = v; const span = block.querySelector('span[data-type="duty-val"]'); if (span) span.textContent = v; }
+            // Update validation for this pin without full re-render
+            const vd = computePinValidation(p);
+            const vEl = card.querySelector('[data-role="validation"]');
+            if (vEl) { vEl.textContent = vd.msg; vEl.className = `validation ${vd.ok ? 'ok' : 'err'}`; }
             render();
           });
           block.addEventListener('click', (e) => {
@@ -462,12 +471,35 @@
           }
         });
 
+        // Set initial validation message for this pin
+        const vd = computePinValidation(p);
+        const vEl = card.querySelector('[data-role="validation"]');
+        if (vEl) { vEl.textContent = vd.msg; vEl.className = `validation ${vd.ok ? 'ok' : 'err'}`; }
         container.appendChild(card);
       });
     }
 
     function validateTimeString(s){
       return s === 'sunrise' || s === 'sunset' || /^\d{2}:\d{2}$/.test(s);
+    }
+
+    // Compute continuity + wrap-around validation for a pin's windows
+    function computePinValidation(p){
+      const wins = (p && p.windows) ? p.windows : [];
+      if (!wins.length) return { ok: false, msg: 'No windows configured' };
+      for (let i=0; i<wins.length-1; i++){
+        const endPrev = String(wins[i].end||'').trim();
+        const startNext = String(wins[i+1].start||'').trim();
+        if (endPrev !== startNext){
+          return { ok: false, msg: `Window ${i+1} end must equal Window ${i+2} start` };
+        }
+      }
+      const firstStart = String(wins[0].start||'').trim();
+      const lastEnd = String(wins[wins.length-1].end||'').trim();
+      if (firstStart !== lastEnd){
+        return { ok: false, msg: `First start (${firstStart}) must equal last end (${lastEnd}) for 24h coverage` };
+      }
+      return { ok: true, msg: 'Windows cover 24h continuously' };
     }
 
     function windowsFromObject(time_windows){


### PR DESCRIPTION
## Validation: window continuity and 24h wrap-around per GPIO

- Added per-GPIO validation ensuring time windows form a continuous 24h cycle:
  - Adjacent continuity: end of window i must equal start of window i+1.
  - Wrap-around: first window’s start must equal last window’s end.
- Inline validation message per GPIO card, live-updated on input.
- Related UX from earlier in this branch:
  - Upload button triggers hidden file input.
  - Window header uses stopwatch emoji; stronger container accent.
  - GPIO and window blocks are collapsible.

Files:
- [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0):
  - CSS: `.validation`, `.validation.ok`, `.validation.err`.
  - JS: [computePinValidation(p)](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:485:4-502:5) and wiring in [renderPinsUI()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:256:4-348:5) input handlers to update messages.

Summary: Ensures basic window time integrity while editing, improving correctness before download/upload.