### PR TITLE
GPIO validation, dropdowns, and download gating

### DIFF
--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -331,9 +331,10 @@
     function addWindowToPin(idx){ if (pins[idx].windows.length < MAX_WINDOWS){ pins[idx].windows.push(newWindow()); renderPinsUI(); render(); } }
     function removeWindowFromPin(pidx, widx){ if (pins[pidx].windows.length > MIN_WINDOWS){ pins[pidx].windows.splice(widx,1); renderPinsUI(); render(); } }
 
-    // Known-good GPIO lists for Pico W
+    // Known-good GPIO lists for Pico W (conservative: only commonly exposed 0–22)
     const GOOD_GPIO = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22];
-    const PWM_GPIO = GOOD_GPIO.slice(); // RP2040 PWM available on these general pins
+    // PWM is broadly available across general GPIOs on RP2040; restrict to exposed set
+    const PWM_GPIO = GOOD_GPIO.slice();
 
     function gpioSelect(current){
       const opts = PWM_GPIO.map(i=>`<option value="${i}" ${i===current? 'selected':''}>${i}</option>`).join('');
@@ -484,11 +485,12 @@
       });
     }
 
-    // Populate hardware GPIO selects with known-good list and defaults
+    // Populate hardware GPIO selects with known-good list and keep current value if set
     function populateHardwareGpioSelects(){
       const make = (sel, defVal) => {
         sel.innerHTML = GOOD_GPIO.map(i=>`<option value="${i}">${i}</option>`).join('');
-        const dv = parseInt(defVal);
+        const cur = sel.value;
+        const dv = isNaN(parseInt(cur)) ? parseInt(defVal) : parseInt(cur);
         const idx = GOOD_GPIO.indexOf(dv);
         sel.selectedIndex = idx >= 0 ? idx : 0;
       };
@@ -740,13 +742,10 @@
         if (cfg.timezone){
           if (cfg.timezone.name !== undefined) document.getElementById('tz_name').value = cfg.timezone.name;
           if (cfg.timezone.offset !== undefined) document.getElementById('tz_offset').value = String(cfg.timezone.offset);
-          const sel = document.getElementById('tz_select');
-          if (sel){
-            const idx = Array.from(sel.options).findIndex(o => o.value === (cfg.timezone.name||''));
-            if (idx >= 0) sel.selectedIndex = idx;
-          }
         }
 
+        // Hardware pins (RTC SDA/SCL) via dropdowns
+        populateHardwareGpioSelects();
         if (cfg.hardware){
           if (cfg.hardware.rtc_sda !== undefined) document.getElementById('rtc_sda').value = cfg.hardware.rtc_sda;
           if (cfg.hardware.rtc_i2c_sda_pin !== undefined) document.getElementById('rtc_sda').value = cfg.hardware.rtc_i2c_sda_pin;
@@ -839,6 +838,7 @@
       if (pins.length === 0) { pins.push(newPin()); }
       populateTimezoneSelect();
       setupTimezoneSearch();
+      populateHardwareGpioSelects();
       setupCollapsibles();
       setupUpload();
       renderPinsUI();

--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -102,10 +102,10 @@
         <legend><span class="legend-row"><button type="button" class="collapse-toggle" aria-label="toggle">▼</button><span class="emoji">🧰</span>Hardware</span></legend>
         <div class="row">
           <label>RTC SDA pin
-            <input id="rtc_sda" type="number" value="20" />
+            <select id="rtc_sda"></select>
           </label>
           <label>RTC SCL pin
-            <input id="rtc_scl" type="number" value="21" />
+            <select id="rtc_scl"></select>
           </label>
         </div>
         <label>PWM frequency (Hz)
@@ -194,12 +194,13 @@
     </form>
 
     <div class="actions">
-      <button type="button" onclick="downloadJSON()">Download config.json</button>
+      <button id="download_btn" type="button" onclick="downloadJSON()">Download config.json</button>
       <button id="upload_btn" type="button">Upload and prefill</button>
       <input id="upload_config" type="file" accept="application/json,.json" style="position:absolute; width:1px; height:1px; padding:0; margin:-1px; border:0; clip:rect(0,0,0,0); overflow:hidden;" />
       <a class="button" href="./index.html">Back to Home</a>
     </div>
     <div id="upload_msg" class="tip"></div>
+    <div id="global_validation" class="tip"></div>
 
     <h2>Preview</h2>
     <pre id="preview"></pre>
@@ -330,8 +331,12 @@
     function addWindowToPin(idx){ if (pins[idx].windows.length < MAX_WINDOWS){ pins[idx].windows.push(newWindow()); renderPinsUI(); render(); } }
     function removeWindowFromPin(pidx, widx){ if (pins[pidx].windows.length > MIN_WINDOWS){ pins[pidx].windows.splice(widx,1); renderPinsUI(); render(); } }
 
+    // Known-good GPIO lists for Pico W
+    const GOOD_GPIO = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22];
+    const PWM_GPIO = GOOD_GPIO.slice(); // RP2040 PWM available on these general pins
+
     function gpioSelect(current){
-      const opts = Array.from({length:23}, (_,i)=>`<option value="${i}" ${i===current? 'selected':''}>${i}</option>`).join('');
+      const opts = PWM_GPIO.map(i=>`<option value="${i}" ${i===current? 'selected':''}>${i}</option>`).join('');
       return `<select data-type="gpio">${opts}</select>`;
     }
     function boolSelect(val){ return `<select data-type="enabled"><option value="true" ${val? 'selected':''}>true</option><option value="false" ${!val? 'selected':''}>false</option></select>`; }
@@ -479,6 +484,70 @@
       });
     }
 
+    // Populate hardware GPIO selects with known-good list and defaults
+    function populateHardwareGpioSelects(){
+      const make = (sel, defVal) => {
+        sel.innerHTML = GOOD_GPIO.map(i=>`<option value="${i}">${i}</option>`).join('');
+        const dv = parseInt(defVal);
+        const idx = GOOD_GPIO.indexOf(dv);
+        sel.selectedIndex = idx >= 0 ? idx : 0;
+      };
+      const sda = document.getElementById('rtc_sda');
+      const scl = document.getElementById('rtc_scl');
+      if (sda) make(sda, 20);
+      if (scl) make(scl, 21);
+    }
+
+    function readRTC(){
+      const sda = parseInt(document.getElementById('rtc_sda').value||'20');
+      const scl = parseInt(document.getElementById('rtc_scl').value||'21');
+      return { sda, scl };
+    }
+
+    function computeGPIOValidation(){
+      const errs = [];
+      const { sda, scl } = readRTC();
+      if (!GOOD_GPIO.includes(sda)) errs.push(`RTC SDA (${sda}) is not a valid Pico W GPIO`);
+      if (!GOOD_GPIO.includes(scl)) errs.push(`RTC SCL (${scl}) is not a valid Pico W GPIO`);
+
+      // Validate each PWM pin is in PWM list
+      pins.forEach((p, idx) => {
+        if (!PWM_GPIO.includes(p.gpio_pin)) errs.push(`PWM Pin ${idx+1} uses invalid GPIO ${p.gpio_pin}`);
+      });
+
+      // Clash detection
+      const usage = new Map();
+      const addUse = (pin, role) => {
+        if (!usage.has(pin)) usage.set(pin, []);
+        usage.get(pin).push(role);
+      };
+      addUse(sda, 'RTC SDA');
+      addUse(scl, 'RTC SCL');
+      pins.forEach((p, idx) => addUse(p.gpio_pin, `PWM pin ${idx+1}`));
+      usage.forEach((roles, pin) => {
+        if (roles.length > 1) errs.push(`GPIO ${pin} is used by: ${roles.join(', ')}`);
+      });
+
+      return errs;
+    }
+
+    function updateGlobalValidation(){
+      // aggregate pin validations
+      const pinErrs = [];
+      pins.forEach((p, idx) => { const vd = computePinValidation(p); if (!vd.ok) pinErrs.push(`GPIO ${p.gpio_pin}: ${vd.msg}`); });
+      const gpioErrs = computeGPIOValidation();
+      const errs = [...pinErrs, ...gpioErrs];
+      const out = document.getElementById('global_validation');
+      const dl = document.getElementById('download_btn');
+      if (errs.length){
+        if (out){ out.innerHTML = errs.map(e=>`❌ ${e}`).join('<br>'); out.style.color = '#b91c1c'; }
+        if (dl){ dl.setAttribute('disabled',''); dl.style.opacity = 0.5; dl.style.cursor='not-allowed'; }
+      } else {
+        if (out){ out.textContent = '✅ All validations passed'; out.style.color = '#065f46'; }
+        if (dl){ dl.removeAttribute('disabled'); dl.style.opacity = 1; dl.style.cursor='pointer'; }
+      }
+    }
+
     function validateTimeString(s){
       return s === 'sunrise' || s === 'sunset' || /^\d{2}:\d{2}$/.test(s);
     }
@@ -620,6 +689,7 @@
     function render(){
       const cfg = buildConfig();
       document.getElementById('preview').textContent = JSON.stringify(cfg, null, 2);
+      updateGlobalValidation();
     }
 
     function downloadJSON(){


### PR DESCRIPTION
# PR Description: GPIO validation, dropdowns, and download gating

## Summary
Enhance the config builder to validate GPIO selections and prevent invalid downloads. Convert RTC pins to dropdowns using known-good Pico W GPIOs, constrain PWM GPIO selection, detect clashes, and gate the “Download config.json” button until all validations pass.

## What changed
- __RTC pins as dropdowns__ in [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0):
  - `rtc_sda`, `rtc_scl` now `<select>` populated by known-good list.
  - Initialization calls [populateHardwareGpioSelects()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:487:4-500:5) in `init()`.
  - [applyConfigToForm()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:731:4-806:5) sets RTC selects from uploaded config.

- __PWM GPIO dropdown constrained__:
  - [gpioSelect()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:328:4-331:5) uses `PWM_GPIO` to populate valid GPIOs.

- __Known-good lists__:
  - `GOOD_GPIO` and `PWM_GPIO` conservatively set to `[0..22]`.

- __Validation and gating__:
  - [computeGPIOValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:508:4-533:5) checks:
    - RTC pins in `GOOD_GPIO`.
    - All PWM pins in `PWM_GPIO`.
    - No clashes across RTC SDA, RTC SCL, and all PWM pins.
  - [computePinValidation(p)](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:556:4-573:5) (from earlier commit) validates time window continuity and 24h wrap-around per GPIO.
  - [updateGlobalValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:535:4-550:5) aggregates all errors, shows them in `#global_validation`, and disables `#download_btn` until resolved.

## Files changed
- [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0)
  - UI: RTC selects; global validation panel `#global_validation`.
  - Logic: `GOOD_GPIO`, `PWM_GPIO`, [populateHardwareGpioSelects()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:487:4-500:5), [computeGPIOValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:508:4-533:5), [updateGlobalValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:535:4-550:5).
  - Hooks: `init()` calls [populateHardwareGpioSelects()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:487:4-500:5). [render()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:690:4-694:5) calls [updateGlobalValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:535:4-550:5).

## How to test
- Change RTC SDA/SCL selections; ensure they are limited to 0–22.
- Assign duplicate GPIO across RTC and PWM pins; see clash error in `#global_validation` and disabled “Download config.json”.
- Edit PWM GPIO dropdowns to invalid combinations; verify errors update live.
- Fix all errors; verify “Download config.json” re-enables and preview updates.
- Upload a config with RTC pins; verify selects reflect uploaded values.