### PR TITLE
Prefill RTC pins + global validation gating

### DIFF
--- a/helper-app/config-builder.html
+++ b/helper-app/config-builder.html
@@ -220,6 +220,26 @@
       return { gpio_pin: gpio, name: `Pin ${gpio}`, enabled: false, windows: [ newWindow() ] };
     }
 
+  // Load RTC SDA/SCL from sample config to prefill hardware selects
+  async function loadSampleHardware(){
+    try {
+      const resp = await fetch('./config.json.sample', { cache: 'no-store' });
+      if (!resp.ok) return;
+      const sample = await resp.json();
+      const hw = sample && sample.hardware || {};
+      const sda = hw.rtc_i2c_sda_pin ?? hw.rtc_sda;
+      const scl = hw.rtc_i2c_scl_pin ?? hw.rtc_scl;
+      if (typeof sda !== 'undefined') {
+        const sel = document.getElementById('rtc_sda');
+        if (sel) sel.value = String(sda);
+      }
+      if (typeof scl !== 'undefined') {
+        const sel = document.getElementById('rtc_scl');
+        if (sel) sel.value = String(scl);
+      }
+    } catch {}
+  }
+
     // Password reveal toggle
     function togglePassword(){
       const input = document.getElementById('password');


### PR DESCRIPTION
# PR Description: Prefill RTC pins + global validation gating

## Summary
Improve hardware pin initialization and validation UX in [helper-app/config-builder.html](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:0:0-0:0). RTC SDA/SCL are prefilled from sample/uploaded config. Time-window and GPIO errors are aggregated in a single panel, and the “Download config.json” button is disabled until all validations pass.

## Changes
- __RTC pin prefill__:
  - Added [loadSampleHardware()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:222:2-240:3) to prefill `rtc_i2c_sda_pin`/`rtc_i2c_scl_pin` from [config.json.sample](cci:7://file:///home/anish/Documents/GitHub/PagodaLightPico/config.json.sample:0:0-0:0).
  - Called during `init()` after [populateHardwareGpioSelects()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:507:4-520:5).
  - [applyConfigToForm()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:729:4-807:5) sets RTC selects from uploaded configs (supports both `rtc_i2c_*` and legacy `rtc_*` keys).

- __Global validation panel + gating__:
  - [updateGlobalValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:555:4-570:5) aggregates:
    - Time window continuity + 24h wrap-around errors from [computePinValidation(p)](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:576:4-593:5).
    - GPIO validity/clash errors from [computeGPIOValidation()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:508:4-533:5).
  - Shows messages in `#global_validation`.
  - Disables `#download_btn` while any errors exist; re-enables when resolved.

- __Bugfix__:
  - Removed illegal `await` inside [applyConfigToForm()](cci:1://file:///home/anish/Documents/GitHub/PagodaLightPico/helper-app/config-builder.html:729:4-807:5).

## How to test
- Load page: RTC SDA/SCL prefill from sample.
- Upload config with RTC pins: selects update accordingly.
- Create time-window mismatch or GPIO clash: errors appear in global panel, download button disabled.
- Fix errors: panel turns green and download re-enables.