### PR TITLE
marketing: refine How-it-compares (typography + mobile + named vendors)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -735,7 +735,7 @@
 
     <div class="lk-mech-header lk-reveal">
       <span class="lk-label">How it compares</span>
-      <p class="lk-mech-figure">
+      <p class="lk-mech-figure lk-cmp-figure">
         The only one that is <b>long-range</b>, <b>gateway-free</b>, and
         <b>fully local</b> at once.
         <span class="lk-mech-sub">No cloud · no subscription · no app — ever.</span>
@@ -867,6 +867,16 @@
             <td><span class="lk-cmp-mark lk-cmp-part">◐</span></td>
             <td><span class="lk-cmp-mark lk-cmp-no">–</span></td>
             <td><span class="lk-cmp-mark lk-cmp-yes">●</span></td>
+          </tr>
+          <!-- A grounding row: each generic bucket named to a real
+               product, so the comparison isn't hand-wavy. -->
+          <tr class="lk-cmp-eg-row">
+            <th scope="row">For example</th>
+            <td class="lk-cmp-lok"><span class="lk-cmp-eg">this</span></td>
+            <td><a class="lk-cmp-eg" href="https://casambi.com" rel="noopener">Casambi</a></td>
+            <td><a class="lk-cmp-eg" href="https://www.lutron.com" rel="noopener">Lutron</a></td>
+            <td><a class="lk-cmp-eg" href="https://www.buildtrack.in" rel="noopener">BuildTrack</a></td>
+            <td><a class="lk-cmp-eg" href="https://www.home-assistant.io" rel="noopener">Home&nbsp;Assistant</a></td>
           </tr>
         </tbody>
       </table>

--- a/site/styles.css
+++ b/site/styles.css
@@ -987,6 +987,14 @@ body.is-bar-visible .lk-bar {
    Lokki's column is washed in copper and its marks are copper. On
    narrow screens the table scrolls horizontally rather than reflow. */
 
+/* Section headline — keep the emphasised words italic (the upright-bold
+   of .lk-mech-figure b reads as a clash mid-sentence; it only works for
+   lone numerals). We harmonise by lifting colour + weight instead. */
+.lk-cmp-figure b {
+  font-style: italic;
+  font-variation-settings: "opsz" 96, "SOFT" 80;
+}
+
 .lk-cmp {
   margin-top: var(--breath-3);
   overflow-x: auto;
@@ -1040,6 +1048,21 @@ body.is-bar-visible .lk-bar {
 }
 .lk-cmp-table thead th:first-child { z-index: 3; }
 
+/* "For example" row — names each generic bucket to a real product so
+   the comparison stays concrete. Quiet by default; copper on hover. */
+.lk-cmp-eg-row th,
+.lk-cmp-eg-row td { padding-top: var(--breath-4); }
+.lk-cmp-eg {
+  font-family: var(--type-glyph);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--ash);
+  border-bottom: none;
+}
+a.lk-cmp-eg { color: var(--ash); border-bottom: 1px solid var(--copper-soft); }
+a.lk-cmp-eg:hover { color: var(--copper); border-color: var(--copper); }
+.lk-cmp-lok .lk-cmp-eg { color: var(--copper); font-style: italic; letter-spacing: 0; }
+
 .lk-cmp-table tbody tr:last-child th,
 .lk-cmp-table tbody tr:last-child td { border-bottom: none; }
 
@@ -1081,6 +1104,22 @@ body.is-bar-visible .lk-bar {
   color: var(--ash);
   max-width: 46ch;
   margin: var(--breath-4) 0 0;
+}
+
+/* Narrow screens: the pinned label column was eating most of the
+   viewport, leaving only Lokki visible. Cap its width and tighten
+   padding so Lokki plus a data column or two read at a glance; long
+   labels wrap within the capped column. */
+@media (max-width: 640px) {
+  .lk-cmp-table { min-width: 520px; }
+  .lk-cmp-table th:first-child {
+    width: 38vw;
+    max-width: 168px;
+    white-space: normal;
+  }
+  .lk-cmp-table th,
+  .lk-cmp-table td { padding: var(--breath-3) var(--breath-2); }
+  .lk-cmp-table tbody th { font-size: 13.5px; }
 }
 
 


### PR DESCRIPTION
Follow-up refinements to the "How it compares" section, from review feedback:

- **(A) Typography** — emphasised headline words ("long-range, gateway-free, fully local") now stay italic. The previous upright-bold reused `.lk-mech-figure b`, which reads well for lone numerals (the "How it works" 56/8/4/2) but clashed mid-sentence against the surrounding italics.
- **(B) Mobile sticky column** — capped the pinned label column at ≤640px (`38vw`, max 168px) with tighter padding, so Lokki plus a data column or two are visible by default instead of only the first column.
- **Named vendors** — added a "For example" row mapping each generic bucket to a real product (Casambi / Lutron / BuildTrack / Home Assistant) so the comparison is concrete, not hand-wavy.

Verified via headless-Chrome screenshots at 1100px and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)