### PR TITLE
Adopt shared starstucklab kit (tokens + family band + footer)

### DIFF
--- a/site/assets/kit/base.css
+++ b/site/assets/kit/base.css
@@ -1,0 +1,116 @@
+/* ==========================================================================
+   STARSTUCK LAB KIT — SHARED PRIMITIVES + PARTIALS
+   --------------------------------------------------------------------------
+   Consumes the --sl-* token contract (see tokens.css). Never hardcodes brand
+   colors or fonts; every value resolves through a token (with a safe fallback).
+
+   Phase 1 scope — the high-value / low-risk shared pieces only:
+     · .sl-wrap     container
+     · .sl-kicker   eyebrow/label
+     · .sl-link     accent link
+     · .sl-family   "Part of starstucklab" band
+     · .sl-footer   build + family columns + signoff
+
+   Per-spoke identity (hero, topbar, band quote, motion gimmicks) is
+   intentionally NOT here — keep that in each spoke's own stylesheet.
+   ========================================================================== */
+
+/* ── Container ── */
+.sl-wrap {
+  width: 100%;
+  max-width: var(--sl-maxw, 1180px);
+  margin-inline: auto;
+  padding-inline: 28px;
+}
+
+/* ── Eyebrow / kicker — mono, accent, wide tracking ── */
+.sl-kicker {
+  display: inline-block;
+  font-family: var(--sl-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--sl-accent, #c9b97a);
+  margin: 0 0 18px;
+}
+
+/* ── Accent link ── */
+.sl-link {
+  color: var(--sl-accent, #c9b97a);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--sl-accent, #c9b97a) 40%, transparent);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.sl-link:hover { border-bottom-color: var(--sl-accent, #c9b97a); }
+
+/* ── Family band: "Part of starstucklab" ── */
+.sl-family h2,
+.sl-family h3 {
+  font-family: var(--sl-font-display, Georgia, serif);
+  font-weight: 600;
+  font-size: clamp(26px, 3.4vw, 38px);
+  line-height: 1.15;
+  color: var(--sl-text, #e8e6e1);
+  margin: 0 0 18px;
+}
+.sl-family p {
+  font-family: var(--sl-font-body, system-ui, sans-serif);
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--sl-text-dim, #8a8780);
+  margin: 0 0 14px;
+  max-width: 46ch;
+}
+
+/* ── Footer: build + family columns + signoff ── */
+.sl-footer {
+  border-top: 1px solid var(--sl-border, #1f1f23);
+  padding: 64px 0 84px;
+}
+.sl-footer-cols {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 60px;
+}
+.sl-footer h4 {
+  font-family: var(--sl-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--sl-text-mute, #5a5854);
+  margin: 0 0 12px;
+}
+.sl-footer p {
+  font-family: var(--sl-font-body, system-ui, sans-serif);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--sl-text-dim, #8a8780);
+  margin: 0;
+}
+.sl-footer a {
+  color: var(--sl-text, #e8e6e1);
+  text-decoration: none;
+  border-bottom: 1px solid var(--sl-border, #1f1f23);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.sl-footer a:hover {
+  border-bottom-color: var(--sl-accent, #c9b97a);
+  color: var(--sl-accent, #c9b97a);
+}
+
+.sl-signoff {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 56px;
+  font-family: var(--sl-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sl-text-mute, #5a5854);
+}
+
+@media (max-width: 800px) {
+  .sl-footer-cols { grid-template-columns: 1fr; gap: 36px; }
+}

--- a/site/assets/kit/tokens.css
+++ b/site/assets/kit/tokens.css
@@ -1,0 +1,33 @@
+/* ==========================================================================
+   STARSTUCK LAB KIT — THEME TOKEN CONTRACT (defaults)
+   --------------------------------------------------------------------------
+   The ~12 variables every spoke may override. base.css consumes ONLY these
+   tokens — never raw colors or font names. A spoke sets its own values in its
+   stylesheet (loaded AFTER this file), and base.css picks them up.
+
+   These defaults are the neutral "lab" look (starlight gold on near-black), so
+   an un-themed spoke still reads as Starstuck Lab.
+   ========================================================================== */
+:root {
+  /* ── Surfaces ── */
+  --sl-bg:        #0b0b0d;   /* page background */
+  --sl-surface:   #131316;   /* elevated surface / card */
+  --sl-border:    #1f1f23;   /* subtle rule / border */
+
+  /* ── Text ── */
+  --sl-text:      #e8e6e1;   /* primary body text */
+  --sl-text-dim:  #8a8780;   /* secondary */
+  --sl-text-mute: #5a5854;   /* tertiary / labels */
+
+  /* ── Accents ── */
+  --sl-accent:    #c9b97a;   /* primary — links, kickers, active */
+  --sl-accent-2:  #6ec1e4;   /* secondary — occasional UI */
+
+  /* ── Type ── */
+  --sl-font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --sl-font-body:    system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --sl-font-mono:    'JetBrains Mono', ui-monospace, Menlo, monospace;
+
+  /* ── Layout ── */
+  --sl-maxw:      1180px;    /* container max-width */
+}

--- a/site/index.html
+++ b/site/index.html
@@ -14,6 +14,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..700,30..100;1,9..144,300..700,30..100&family=Manrope:wght@400;500;600&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/kit/tokens.css" />
+  <link rel="stylesheet" href="assets/kit/base.css" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="icon" type="image/svg+xml" href="assets/mark.svg" />
 </head>
@@ -917,18 +919,11 @@
           </li>
         </ul>
       </div>
-      <div>
-        <span class="lk-label">Kin</span>
-        <h3>Part of <a href="https://starstucklab.com">starstucklab</a>.</h3>
-        <p>
-          A small ecosystem of personal engineering instruments, each built to
-          solve one specific problem and then, ideally, stop demanding
-          attention.
-        </p>
-        <p>
-          Where science met poetry, had a brief fling with engineering, and now
-          raises mildly disillusioned but talented offspring.
-        </p>
+      <div class="sl-family">
+        <span class="sl-kicker">Kin</span>
+        <h3>Part of <a class="sl-link" href="https://starstucklab.com">starstucklab</a>.</h3>
+        <p>A small ecosystem of personal engineering instruments, each built to solve one specific problem and then, ideally, stop demanding attention.</p>
+        <p>Where science met poetry, had a brief fling with engineering, and now raises mildly disillusioned but talented offspring.</p>
       </div>
     </div>
   </div>
@@ -936,27 +931,21 @@
 
 
 <!-- ============ FOOTER ============ -->
-<footer class="lk-foot">
-  <div class="lk-foot-inner">
-    <div class="lk-foot-cols">
+<footer class="sl-footer">
+  <div class="sl-wrap">
+    <div class="sl-footer-cols">
       <div>
         <h4>The build</h4>
-        <p>
-          Firmware, schematics, schemas, dashboard:<br>
-          <a href="https://github.com/m-anish/lokki">github.com/m-anish/lokki&nbsp;↗</a>
-        </p>
+        <p>Schematics, firmware, BOM, wiring:<br><a href="https://github.com/m-anish/lokki">github&nbsp;↗</a></p>
       </div>
       <div>
         <h4>The family</h4>
-        <p>
-          <a href="https://github.com/m-anish/starstucklab">starstucklab&nbsp;↗</a><br>
-          Other small machines.
-        </p>
+        <p><a href="https://github.com/m-anish/starstucklab">starstucklab&nbsp;↗</a><br>Other small machines.</p>
       </div>
     </div>
-    <div class="lk-foot-sign">
+    <div class="sl-signoff">
       <span>○ Lokki · GPL-3.0 · MMXXVI</span>
-      <span>A <a href="https://starstucklab.com">starstucklab</a> project · small machines for an indifferent universe.</span>
+      <span>Building small machines for an indifferent universe.</span>
     </div>
   </div>
 </footer>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,3 +1,19 @@
+/* Starstuck Lab kit — lokki theme overrides */
+:root {
+  --sl-bg:        #0d0e10;
+  --sl-surface:   #15171a;
+  --sl-border:    #181918;
+  --sl-text:      #ece9e0;
+  --sl-text-dim:  #8e8d88;
+  --sl-text-mute: #5f5e5a;
+  --sl-accent:    #c66a44;
+  --sl-accent-2:  #3da8a8;
+  --sl-font-display: 'Fraunces', Georgia, serif;
+  --sl-font-body:    'Manrope', system-ui, sans-serif;
+  --sl-font-mono:    'Space Mono', ui-monospace, Menlo, monospace;
+  --sl-maxw:      1080px;
+}
+
 /* ============================================================
    lokki — marketing site
    ----------------------------------------------------------


### PR DESCRIPTION
Links the vendored kit (assets/kit/), maps the spoke onto the --sl-* token contract, and swaps the family band + footer to the shared .sl-* partials. Additive only — no CSS removed; bespoke hero, motion, and signoff untouched. Reviewed locally.